### PR TITLE
Bump Apache Beam version from 2.0.0 to 2.4.0

### DIFF
--- a/udfs/beam/pom.xml
+++ b/udfs/beam/pom.xml
@@ -34,7 +34,7 @@
   <url>http://github.com/nielsbasjes/yauaa</url>
 
   <properties>
-    <beam.version>2.0.0</beam.version>
+    <beam.version>2.4.0</beam.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Hi @nielsbasjes 

Thanks for developing this awesome library. Currently we're running Apache Beam 2.4 (using the Google Dataflow Java sdk). Maybe you want to bump this version as well to keep up to date.

Cheers, Fokko