### PR TITLE
Add Speedcurve mobile robot matcher and modify test cases accordingly

### DIFF
--- a/analyzer/src/main/resources/UserAgents/Robots.yaml
+++ b/analyzer/src/main/resources/UserAgents/Robots.yaml
@@ -2421,8 +2421,7 @@ config:
 - matcher:
     require:
     - 'agent.product.(1)version="SpeedCurve"'
-    - 'agent.product.name{"Mobile"'
-    - 'agent.product.name}"Safari"'
+    - 'agent.product.name[1-1]="Mobile"'
     variable:
     - 'PTSTVersion:agent.product.name="PTST"^.(2)version'
     extract:
@@ -2439,6 +2438,27 @@ config:
     - 'AgentClass                          :   6001 : "Robot"'
     - 'AgentName                           :   6001 : "SpeedCurve WebpageTest"'
     - 'AgentVersion                        :   6001 : @PTSTVersion'
+
+- matcher:
+    require:
+    - 'agent.product.(1)version="SpeedCurve"'
+    - 'agent.(1)product.(1)comments.(2)entry[1-1]="Android"'
+    variable:
+    - 'PTSTVersion:agent.product.name="PTST"^.(2)version'
+    extract:
+    - '__Set_ALL_Fields__                  :   6999 : "<<<null>>>"' # Must be 1 lower than the rest (or you will wipe yourself too)
+    - 'DeviceClass                         :   7001 : "Robot Mobile"'
+    - 'DeviceName                          :   7001 : "SpeedCurve WebpageTest"'
+    - 'DeviceBrand                         :   7001 : "SpeedCurve"'
+    - 'OperatingSystemClass                :   7001 : "Cloud"'
+    - 'OperatingSystemName                 :   7001 : "Cloud"'
+    - 'OperatingSystemVersion              :   7001 : "??"'
+    - 'LayoutEngineClass                   :   7001 : "Robot"'
+    - 'LayoutEngineName                    :   7001 : "SpeedCurve WebpageTest"'
+    - 'LayoutEngineVersion                 :   7001 : @PTSTVersion'
+    - 'AgentClass                          :   7001 : "Robot"'
+    - 'AgentName                           :   7001 : "SpeedCurve WebpageTest"'
+    - 'AgentVersion                        :   7001 : @PTSTVersion'
 
 - test:
     input:
@@ -2585,6 +2605,29 @@ config:
       AgentNameVersion                     : 'SpeedCurve WebpageTest 180620.180643'
       AgentNameVersionMajor                : 'SpeedCurve WebpageTest 180620'
 
+- test:
+    input:
+      user_agent_string: 'Mozilla/5.0 (Linux; Android 4.3; Nexus 10 Build/JSS15Q) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.76 Safari/537.36 PTST/SpeedCurve/190429.170455'
+    expected:
+      DeviceClass                          : 'Robot Mobile'
+      DeviceName                           : 'SpeedCurve WebpageTest'
+      DeviceBrand                          : 'SpeedCurve'
+      OperatingSystemClass                 : 'Cloud'
+      OperatingSystemName                  : 'Cloud'
+      OperatingSystemVersion               : '??'
+      OperatingSystemNameVersion           : 'Cloud ??'
+      LayoutEngineClass                    : 'Robot'
+      LayoutEngineName                     : 'SpeedCurve WebpageTest'
+      LayoutEngineVersion                  : '190429.170455'
+      LayoutEngineVersionMajor             : '190429'
+      LayoutEngineNameVersion              : 'SpeedCurve WebpageTest 190429.170455'
+      LayoutEngineNameVersionMajor         : 'SpeedCurve WebpageTest 190429'
+      AgentClass                           : 'Robot'
+      AgentName                            : 'SpeedCurve WebpageTest'
+      AgentVersion                         : '190429.170455'
+      AgentVersionMajor                    : '190429'
+      AgentNameVersion                     : 'SpeedCurve WebpageTest 190429.170455'
+      AgentNameVersionMajor                : 'SpeedCurve WebpageTest 190429'
 
 - test:
     input:

--- a/analyzer/src/main/resources/UserAgents/Robots.yaml
+++ b/analyzer/src/main/resources/UserAgents/Robots.yaml
@@ -2418,6 +2418,28 @@ config:
     - 'AgentName                           :   5001 : "SpeedCurve WebpageTest"'
     - 'AgentVersion                        :   5001 : @PTSTVersion'
 
+- matcher:
+    require:
+    - 'agent.product.(1)version="SpeedCurve"'
+    - 'agent.product.name{"Mobile"'
+    - 'agent.product.name}"Safari"'
+    variable:
+    - 'PTSTVersion:agent.product.name="PTST"^.(2)version'
+    extract:
+    - '__Set_ALL_Fields__                  :   5999 : "<<<null>>>"' # Must be 1 lower than the rest (or you will wipe yourself too)
+    - 'DeviceClass                         :   6001 : "Robot Mobile"'
+    - 'DeviceName                          :   6001 : "SpeedCurve WebpageTest"'
+    - 'DeviceBrand                         :   6001 : "SpeedCurve"'
+    - 'OperatingSystemClass                :   6001 : "Cloud"'
+    - 'OperatingSystemName                 :   6001 : "Cloud"'
+    - 'OperatingSystemVersion              :   6001 : "??"'
+    - 'LayoutEngineClass                   :   6001 : "Robot"'
+    - 'LayoutEngineName                    :   6001 : "SpeedCurve WebpageTest"'
+    - 'LayoutEngineVersion                 :   6001 : @PTSTVersion'
+    - 'AgentClass                          :   6001 : "Robot"'
+    - 'AgentName                           :   6001 : "SpeedCurve WebpageTest"'
+    - 'AgentVersion                        :   6001 : @PTSTVersion'
+
 - test:
     input:
       user_agent_string: 'Mozilla/5.0 (Linux; Android 6.0.1; Moto G (4) Build/MPJ24.139-64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.146 Mobile Safari/537.36 PTST/180521.140508'
@@ -2519,7 +2541,7 @@ config:
     input:
       user_agent_string: 'Mozilla/5.0 (iPad; CPU OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B137 Safari/601.1 PTST/SpeedCurve/180620.180643'
     expected:
-      DeviceClass                          : 'Robot'
+      DeviceClass                          : 'Robot Mobile'
       DeviceName                           : 'SpeedCurve WebpageTest'
       DeviceBrand                          : 'SpeedCurve'
       OperatingSystemClass                 : 'Cloud'
@@ -2543,7 +2565,7 @@ config:
     input:
       user_agent_string: 'Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1 PTST/SpeedCurve/180620.180643'
     expected:
-      DeviceClass                          : 'Robot'
+      DeviceClass                          : 'Robot Mobile'
       DeviceName                           : 'SpeedCurve WebpageTest'
       DeviceBrand                          : 'SpeedCurve'
       OperatingSystemClass                 : 'Cloud'


### PR DESCRIPTION
Thanks a bunch for this library, @nielsbasjes!  I've attempted to update Speedcurve matcher to account for their mobile simulators (updated the tests as well).  All of their mobile simulators still look like the tests in the file (and the desktop one looks like the desktop test), just need to segment them properly between mobile and desktop.

Not sure if I did things in the most efficient way, but the tests did pass - https://api.travis-ci.org/v3/job/526273600/log.txt. :)  