### PR TITLE
Fix UDF build issues that affect Hive2.x releases with Tez.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,16 @@ This is a java library that tries to parse and analyze the useragent string and 
 
 The full documentation can be found here [https://yauaa.basjes.nl](https://yauaa.basjes.nl)
 
+EMR Compatible Build
+===========================
+!!!!!! IMPORTANT !!!!!!!
+For building emr compatible udf please checkout hive-tez-5.11 and run
+
+```mvn -Dmaven.test.skip=true -pl :yauaa-hive -am clean package```
+
+Built jar can be found in udfs/hive/target/yauaa-hive-5.11.jar. You can see example usage [here](https://yauaa.basjes.nl/UDF-ApacheHive.html).
+
+
 HIGH Profile release notes:
 ===========================
 
@@ -26,7 +36,7 @@ The detection system for the DeviceBrand has been rewritten and as a consequence
 Version 5.5
 ---
 With Google Chrome 70 the useragent string pattern has been changed on Android ( https://www.chromestatus.com/feature/4558585463832576 ) .
-As a consequence the detection of the DeviceBrand failed and you always get "Unknown". 
+As a consequence the detection of the DeviceBrand failed and you always get "Unknown".
 This has been fixed in Yauaa 5.5.
 
 Version 5.1 is bad.
@@ -35,7 +45,7 @@ If you are using version 5.1 you should upgrade IMMEDIATELY because 5.1 crashes 
 
     Mozilla/1.2.3 (http://basjes.nl)
 
-Blog post 
+Blog post
 =========
 A bit more background about this useragent parser can be found in this blog which I wrote about it: [https://techlab.bol.com/making-sense-user-agent-string/](https://partnerprogramma.bol.com/click/click?p=1&t=url&s=2171&f=TXL&url=https%3A%2F%2Ftechlab.bol.com%2Fmaking-sense-user-agent-string%2F&name=yauaa)
 

--- a/README.md
+++ b/README.md
@@ -11,16 +11,6 @@ This is a java library that tries to parse and analyze the useragent string and 
 
 The full documentation can be found here [https://yauaa.basjes.nl](https://yauaa.basjes.nl)
 
-EMR Compatible Build
-===========================
-!!!!!! IMPORTANT !!!!!!!
-For building emr compatible udf please checkout hive-tez-5.11 and run
-
-```mvn -Dmaven.test.skip=true -pl :yauaa-hive -am clean package```
-
-Built jar can be found in udfs/hive/target/yauaa-hive-5.11.jar. You can see example usage [here](https://yauaa.basjes.nl/UDF-ApacheHive.html).
-
-
 HIGH Profile release notes:
 ===========================
 
@@ -36,7 +26,7 @@ The detection system for the DeviceBrand has been rewritten and as a consequence
 Version 5.5
 ---
 With Google Chrome 70 the useragent string pattern has been changed on Android ( https://www.chromestatus.com/feature/4558585463832576 ) .
-As a consequence the detection of the DeviceBrand failed and you always get "Unknown".
+As a consequence the detection of the DeviceBrand failed and you always get "Unknown". 
 This has been fixed in Yauaa 5.5.
 
 Version 5.1 is bad.
@@ -45,7 +35,7 @@ If you are using version 5.1 you should upgrade IMMEDIATELY because 5.1 crashes 
 
     Mozilla/1.2.3 (http://basjes.nl)
 
-Blog post
+Blog post 
 =========
 A bit more background about this useragent parser can be found in this blog which I wrote about it: [https://techlab.bol.com/making-sense-user-agent-string/](https://partnerprogramma.bol.com/click/click?p=1&t=url&s=2171&f=TXL&url=https%3A%2F%2Ftechlab.bol.com%2Fmaking-sense-user-agent-string%2F&name=yauaa)
 

--- a/udfs/hive/pom.xml
+++ b/udfs/hive/pom.xml
@@ -152,6 +152,53 @@
       </plugin>
 
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>inject-problematic-dependencies</id>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <relocations>
+                <relocation>
+                  <pattern>org.springframework</pattern>
+                  <shadedPattern>nl.basjes.shaded.org.springframework</shadedPattern>
+                  <includes>
+                    <include>org.springframework.**</include>
+                  </includes>
+                </relocation>
+                <relocation>
+                  <pattern>org.antlr</pattern>
+                  <shadedPattern>nl.basjes.shaded.org.antlr</shadedPattern>
+                  <includes>
+                    <include>org.antlr.**</include>
+                  </includes>
+                </relocation>
+                <relocation>
+                  <pattern>org.yaml.snakeyaml</pattern>
+                  <shadedPattern>nl.basjes.shaded.org.yaml.snakeyaml</shadedPattern>
+                  <includes>
+                    <include>org.yaml.snakeyaml.**</include>
+                  </includes>
+                </relocation>
+                <relocation>
+                  <pattern>com.google</pattern>
+                  <shadedPattern>nl.basjes.shaded.com.google</shadedPattern>
+                  <includes>
+                    <include>com.google.**</include>
+                  </includes>
+                </relocation>
+              </relocations>
+            </configuration>
+          </execution>
+
+        </executions>
+      </plugin>
+
+      <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
       </plugin>


### PR DESCRIPTION
For some unknown reason Hive and Tez add their own version of Google's Guava library. That causes Classpath conflicts and breaks the UDF completely - addressed this with Maven shading.
I saw that you had addressed the same issue already for Analyzer package. Unfortunately the maven-assembly-plugin used in udfs/hive/pom.xml just adds unshaded version of guava in its super jar output.  