### PR TITLE
add honor brand under huawei

### DIFF
--- a/analyzer/src/main/resources/UserAgents/MobileBrands.yaml
+++ b/analyzer/src/main/resources/UserAgents/MobileBrands.yaml
@@ -36,6 +36,7 @@ config:
       "eZee"                    : "eZee"
       "Fairphone"               : "Fairphone"
       "General Mobile"          : "General Mobile"
+      "Honor"                   : "Huawei"
       "HP"                      : "HP"
       "HTC"                     : "HTC"
       "Huawei"                  : "Huawei"


### PR DESCRIPTION
When testing with this lib, I found that some UA coundn't be detected, such as 
> Dalvik/2.1.0 (Linux; U; Android 9; HLK-AL00 Build/HONORHLK-AL00)

which would be recognized as brand HLK.

Then I found that there're many prefixes for Huawei in *MobileBrands.yaml*,  such as *ALE-*, *ATH-*
but the list could grow larger and larger when new models/versions come out.

Currently, *HUAWEI* or *HONOR* could be found in UA of Huawei phone, so just search these two words would be more reliable.