### PR TITLE
build: Skip jacoco for flink-table to fix build with Flink 1.17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -995,11 +995,11 @@
     <module>devtools</module>
     <module>analyzer</module>
     <module>udfs</module>
-<!--    <module>webapp</module>-->
-<!--    <module>benchmarks</module>-->
-<!--    <module>documentation</module>-->
-    <!-- <module>devtools/log2test</module>-->
-    <!-- <module>devtools/analysis/loader/</module> -->
+    <module>webapp</module>
+    <module>benchmarks</module>
+    <module>documentation</module>
+    <module>devtools/log2test</module>
+    <module>devtools/analysis/loader/</module>
   </modules>
 
   <licenses>

--- a/udfs/flink-table/pom.xml
+++ b/udfs/flink-table/pom.xml
@@ -135,6 +135,9 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
       </plugin>
 
     </plugins>

--- a/udfs/pom.xml
+++ b/udfs/pom.xml
@@ -75,17 +75,17 @@
   <!-- ======================================================= -->
 
   <modules>
-<!--    <module>logparser</module>-->
+    <module>logparser</module>
     <module>flink</module>
     <module>flink-table</module>
-<!--    <module>beam</module>-->
-<!--    <module>beam-sql</module>-->
-<!--    <module>hive</module>-->
-<!--    <module>drill</module>-->
-<!--    <module>nifi</module>-->
-<!--    <module>elastic</module>-->
-<!--    <module>snowflake</module>-->
-<!--    <module>trino</module>-->
+    <module>beam</module>
+    <module>beam-sql</module>
+    <module>hive</module>
+    <module>drill</module>
+    <module>nifi</module>
+    <module>elastic</module>
+    <module>snowflake</module>
+    <module>trino</module>
   </modules>
 
   <build>


### PR DESCRIPTION
It looks like jacoco generates `$jacocoInit()` methods like
```java
private static boolean[] org.apache.calcite.rel.metadata.BuiltInMetadata$Predicates$Handler.$jacocoInit()
```
At the same time Calcite does expect only metadata methods with 2+ args
