### PR TITLE
fix: extend User Agent client hints platform version windows 11 mapping

### DIFF
--- a/analyzer/src/main/java/nl/basjes/parse/useragent/clienthints/ClientHintsAnalyzer.java
+++ b/analyzer/src/main/java/nl/basjes/parse/useragent/clienthints/ClientHintsAnalyzer.java
@@ -144,6 +144,9 @@ public class ClientHintsAnalyzer extends ClientHintsHeadersParser {
         WINDOWS_VERSION_MAPPING.put("14",  new OSFields("Windows NT", "11",  "11", "Windows 11",  "Windows 11"));
         WINDOWS_VERSION_MAPPING.put("15",  new OSFields("Windows NT", "11",  "11", "Windows 11",  "Windows 11"));
         WINDOWS_VERSION_MAPPING.put("16",  new OSFields("Windows NT", "11",  "11", "Windows 11",  "Windows 11"));
+        WINDOWS_VERSION_MAPPING.put("17",  new OSFields("Windows NT", "11",  "11", "Windows 11",  "Windows 11"));
+        WINDOWS_VERSION_MAPPING.put("18",  new OSFields("Windows NT", "11",  "11", "Windows 11",  "Windows 11"));
+        WINDOWS_VERSION_MAPPING.put("19",  new OSFields("Windows NT", "11",  "11", "Windows 11",  "Windows 11"));
     }
 
     public MutableUserAgent merge(AnalyzerConfigHolder config, MutableUserAgent userAgent, ClientHints clientHints) {


### PR DESCRIPTION
Windows 11 sdk [10.0.26100](https://developer.microsoft.com/en-us/windows/downloads/windows-sdk/) introduce Windows.Foundation.UniversalApiContract: 19.0.0.0. which is used for [Sec-CH-UA-Platform-Version header](https://wicg.github.io/ua-client-hints/#sec-ch-ua-platform)