### PR TITLE
refactor: Make UserAgentAnalyzer constructor private

### DIFF
--- a/analyzer/src/main/java/nl/basjes/parse/useragent/UserAgentAnalyzer.java
+++ b/analyzer/src/main/java/nl/basjes/parse/useragent/UserAgentAnalyzer.java
@@ -53,4 +53,8 @@ public final class UserAgentAnalyzer extends AbstractUserAgentAnalyzer implement
         AbstractUserAgentAnalyzer.configureKryo(kryo);
     }
 
+    private UserAgentAnalyzer() {
+        super();
+    }
+
 }


### PR DESCRIPTION
This PR changes `UserAgentAnalyzer` constructor private to enforce its builder.